### PR TITLE
Make ServiceLocator thread-safe

### DIFF
--- a/Tests/ServiceInjectorTests/InjectPropertyWrapperTests.swift
+++ b/Tests/ServiceInjectorTests/InjectPropertyWrapperTests.swift
@@ -21,7 +21,7 @@ final class InjectPropertyWrapperTests: XCTestCase {
     func testInjectPropertyWrapper() {
         // Registro de un servicio de prueba en el ServiceLocator
         let testService = TestService()
-        try? ServiceLocator.register(as: TestServiceProtocol.self, using: testService)
+        try? ServiceLocator.register(as: TestServiceProtocol.self, withLifecycle: .runtime, using: testService)
         
         // Uso de @Inject para inyectar el servicio en una propiedad
         class TestConsumer {

--- a/Tests/ServiceInjectorTests/ServiceLocatorRegisterAndRetrieveTests.swift
+++ b/Tests/ServiceInjectorTests/ServiceLocatorRegisterAndRetrieveTests.swift
@@ -19,9 +19,9 @@ final class ServiceLocatorRegisterAndRetrieveTests: XCTestCase {
     
     func testServiceRegistrationAndRetrieval() {
         do {
-            try ServiceLocator.register(as: TestServiceProtocol.self, using: TestService())
-            
-            let service: TestServiceProtocol = try ServiceLocator.locateService(ofType: TestServiceProtocol.self)
+            try ServiceLocator.register(as: TestServiceProtocol.self, withLifecycle: .runtime, using: TestService())
+
+            let service: TestServiceProtocol = try ServiceLocator.locateService(ofType: TestServiceProtocol.self, withLifecycle: .runtime)
             
             XCTAssertTrue(service is TestService, "El servicio localizado debe ser de tipo TestService.")
         } catch ServiceLocatorError.serviceAlreadyRegistered(let serviceName) {

--- a/Tests/ServiceInjectorTests/ServiceLocatorRegisterDiplicateFailTests.swift
+++ b/Tests/ServiceInjectorTests/ServiceLocatorRegisterDiplicateFailTests.swift
@@ -21,10 +21,10 @@ final class ServiceLocatorRegisterDiplicateFailTests: XCTestCase {
     // Test failure to register a service that already exists without using the override method
     func testRegisterDuplicateServiceWithoutOverrideShouldFail() {
         // Attempt to register the service for the first time
-        XCTAssertNoThrow(try ServiceLocator.register(as: TestServiceProtocol.self, using: TestService()), "First registration should succeed.")
+        XCTAssertNoThrow(try ServiceLocator.register(as: TestServiceProtocol.self, withLifecycle: .runtime, using: TestService()), "First registration should succeed.")
         
         // Attempt to register the same service again and expect an error
-        XCTAssertThrowsError(try ServiceLocator.register(as: TestServiceProtocol.self, using: TestService())) { error in
+        XCTAssertThrowsError(try ServiceLocator.register(as: TestServiceProtocol.self, withLifecycle: .runtime, using: TestService())) { error in
             // Verify the error is the expected type and value
             guard let serviceLocatorError = error as? ServiceLocatorError else {
                 return XCTFail("Expected ServiceLocatorError")

--- a/Tests/ServiceInjectorTests/ServiceLocatorServiceOverrideTests.swift
+++ b/Tests/ServiceInjectorTests/ServiceLocatorServiceOverrideTests.swift
@@ -20,16 +20,16 @@ final class ServiceLocatorServiceOverrideTests: XCTestCase {
     // Test that a registered service can be successfully overridden
     func testServiceOverride() {
         // Register the initial service implementation
-        XCTAssertNoThrow(try ServiceLocator.register(as: TestServiceProtocol.self, using: TestService()), "Initial registration should succeed.")
+        XCTAssertNoThrow(try ServiceLocator.register(as: TestServiceProtocol.self, withLifecycle: .runtime, using: TestService()), "Initial registration should succeed.")
         
         // Define a new service implementation to override the existing one
         class TestServiceOverride: TestServiceProtocol {}
         
         // Attempt to override the previously registered service
-        ServiceLocator.override(as: TestServiceProtocol.self, using: TestServiceOverride())
+        ServiceLocator.override(as: TestServiceProtocol.self, withLifecycle: .runtime, using: TestServiceOverride())
         
         // Locate the service after overriding
-        let locatedService: TestServiceProtocol = try! ServiceLocator.locateService(ofType: TestServiceProtocol.self)
+        let locatedService: TestServiceProtocol = try! ServiceLocator.locateService(ofType: TestServiceProtocol.self, withLifecycle: .runtime)
         
         // Verify that the located service is an instance of the override class
         XCTAssertTrue(locatedService is TestServiceOverride, "The located service should be an instance of the override class.")

--- a/Tests/ServiceInjectorTests/ServiceLocatorThreadSafetyTests.swift
+++ b/Tests/ServiceInjectorTests/ServiceLocatorThreadSafetyTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import ServiceInjector
+
+final class ServiceLocatorThreadSafetyTests: XCTestCase {
+
+    override func tearDownWithError() throws {
+        ServiceLocator.clearCache()
+    }
+
+    func testConcurrentSingletonAccessReturnsSameInstance() {
+        let service = TestService()
+        try? ServiceLocator.register(as: TestServiceProtocol.self, withLifecycle: .singleton, using: service)
+
+        let expectation = XCTestExpectation(description: "Concurrent access")
+        expectation.expectedFulfillmentCount = 10
+
+        let queue = DispatchQueue.global(qos: .userInitiated)
+        for _ in 0..<10 {
+            queue.async {
+                let retrieved: TestServiceProtocol = try! ServiceLocator.locateService(ofType: TestServiceProtocol.self, withLifecycle: .singleton)
+                XCTAssertTrue(retrieved as AnyObject === service)
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+}


### PR DESCRIPTION
## Summary
- add serial queue to `ServiceLocator`
- synchronize reads/writes to `cache` and `serviceFactories`
- update existing unit tests for new API
- add a multithreaded test verifying concurrent access

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685cc955f9c88330a0b40f4f2907676a