### PR TITLE
Add async injection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ class MyViewController: UIViewController {
     }
 }
 ```
+
+### Asynchronous Injection
+`@AsyncInject` allows awaiting services with Swift concurrency:
+```swift
+class AsyncConsumer {
+    @AsyncInject var myService: Task<MyServiceProtocol, Error>
+
+    func load() async throws {
+        let service = try await myService.value
+        service.performAction()
+    }
+}
+```
 ### Unregistering Services
 If needed, you can unregister services:
 ```swift

--- a/Sources/ServiceInjector/ServiceInjector.swift
+++ b/Sources/ServiceInjector/ServiceInjector.swift
@@ -58,3 +58,25 @@ public struct Inject<T> {
         mutating set { service = newValue }
     }
 }
+
+/// A property wrapper for asynchronous dependency injection.
+@propertyWrapper
+public struct AsyncInject<T> {
+    private var task: Task<T, Error>
+
+    public init(_ lifecycle: ServiceLifecycle = .runtime, identifier: String? = nil) {
+        self.task = Task {
+            try await ServiceLocator.locateServiceAsync(ofType: T.self, withLifecycle: lifecycle, withIdentifier: identifier)
+        }
+    }
+
+    public var wrappedValue: Task<T, Error> {
+        get { task }
+        mutating set { task = newValue }
+    }
+
+    public var projectedValue: Task<T, Error> {
+        get { task }
+        mutating set { task = newValue }
+    }
+}

--- a/Tests/ServiceInjectorTests/AsyncInjectPropertyWrapperTests.swift
+++ b/Tests/ServiceInjectorTests/AsyncInjectPropertyWrapperTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import ServiceInjector
+
+final class AsyncInjectPropertyWrapperTests: XCTestCase {
+    override func tearDownWithError() throws {
+        ServiceLocator.clearCache()
+    }
+
+    func testAsyncInjectPropertyWrapper() async throws {
+        let service = TestService()
+        try ServiceLocator.register(as: TestServiceProtocol.self, withLifecycle: .runtime, using: service)
+
+        class Consumer {
+            @AsyncInject var injected: Task<TestServiceProtocol, Error>
+        }
+
+        let consumer = Consumer()
+        let retrieved = try await consumer.injected.value
+        XCTAssertTrue(retrieved as AnyObject === service)
+    }
+}

--- a/Tests/ServiceInjectorTests/ServiceLocatorAsyncTests.swift
+++ b/Tests/ServiceInjectorTests/ServiceLocatorAsyncTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import ServiceInjector
+
+final class ServiceLocatorAsyncTests: XCTestCase {
+    override func tearDownWithError() throws {
+        ServiceLocator.clearCache()
+    }
+
+    func testLocateServiceAsync() async throws {
+        try ServiceLocator.register(as: TestServiceProtocol.self, withLifecycle: .runtime, using: TestService())
+        let service: TestServiceProtocol = try await ServiceLocator.locateServiceAsync(ofType: TestServiceProtocol.self, withLifecycle: .runtime)
+        XCTAssertTrue(service is TestService)
+    }
+}


### PR DESCRIPTION
## Summary
- add async service lookup to `ServiceLocator`
- implement `@AsyncInject` property wrapper using `Task`
- show async usage in README
- test async service location and async property wrapper

## Testing
- `swift test --disable-sandbox`

------
https://chatgpt.com/codex/tasks/task_e_685cd189d6808330974d139f70218f01